### PR TITLE
Add metadata to report page.

### DIFF
--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -6,8 +6,9 @@ import { getRepoAndLabels } from '@/util/GitHub/get-repo-labels'
 import CountDownTimer from '@/components/countdown/countdownTimer'
 
 export const metadata: Metadata = {
-    title: 'Report an Issue - Starfield Community Patch'
-}
+    title: 'Report an Issue - Starfield Community Patch',
+    description: 'The home of the Starfield Community Patch project. Remember, the Community Patch is only intended to fix bugs and errors in the base game.',
+  }
 
 const orb = Orbitron({ subsets: ['latin'] })
 


### PR DESCRIPTION
This addresses issue #4 

I don't know how to setup the project locally but my best guess on how the embed will look like is like this.

![image](https://github.com/Starfield-Community-Patch/Website/assets/132364/f88af1e2-9b06-465c-bdad-9571b8fcfafe)

Im open to changing the title and description, those are just my best guesses for something.
The option to add images is also possible.