### PR TITLE
Provide Error Text In Production for Join Team Form

### DIFF
--- a/src/app/api/join/route.ts
+++ b/src/app/api/join/route.ts
@@ -4,34 +4,34 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
     const org = req.nextUrl.searchParams.get('org');
-    if (!org) return NextResponse.json({}, { status: 422, statusText: 'No `org` query parameter.' })
+    if (!org) return NextResponse.json({statusText: 'No `org` query parameter.'}, { status: 422 })
 
     const formData = await req.formData()
 
     const email = formData.get('email');
-    if (!email) return NextResponse.json({}, { status: 422, statusText: 'No `email` form data.' })
-    if (typeof email !== 'string') return NextResponse.json({}, { status: 422, statusText: 'The email you have submitted is invalid.' })
+    if (!email) return NextResponse.json({statusText: 'No `email` form data.'}, { status: 422})
+    if (typeof email !== 'string') return NextResponse.json({statusText: 'The email you have submitted is invalid.'}, { status: 422 })
     // If we were to validate the email ourselves, we'd undoubtedly have a different implementation than GitHub.
 
     const teamsRaw = formData.getAll('teams[]');
-    if (!teamsRaw || teamsRaw.length === 0) return NextResponse.json({}, { status: 422, statusText: 'No `teams[]` form data.' })
+    if (!teamsRaw || teamsRaw.length === 0) return NextResponse.json({statusText: 'No `teams[]` form data.'}, { status: 422 })
 
     const team_ids = teamsRaw.filter(t => t !== 'unselected').map(t => parseInt(t.toString()));
-    if (!team_ids.every(t => !isNaN(t))) return NextResponse.json({}, { status: 422, statusText: 'Invalid `teams[]` form data.' })
+    if (!team_ids.every(t => !isNaN(t))) return NextResponse.json({statusText: 'Invalid `teams[]` form data.'}, { status: 422 })
 
     const res = await inviteTeamMember({
         email,
         team_ids,
         org,
         role: 'direct_member'
-    }).catch(e => e as ErrorWithHTTPCode);
+    }).catch(e => { if (e instanceof ErrorWithHTTPCode) return e; else throw e });
 
-    //if (!res) return NextResponse.json({}, { status: 500, statusText: 'Internal Server Error - GitHub API Error' })
+    const statusText = 'response' in res && res.response && typeof res.response === 'object' && 'data' in res.response && res.response.data && typeof res.response.data === 'object' && 'message' in res.response.data && typeof res.response.data.message === 'string' ? res.response.data.message : 'Internal Server Error - Unspecified GitHub API Error'
 
     if (res instanceof ErrorWithHTTPCode) {
         console.error(res)
-        return NextResponse.json(('response' in res && res.response) ?? {}, { status: res.code, statusText: 'response' in res && res.response && typeof res.response === 'object' && 'data' in res.response && res.response.data && typeof res.response.data === 'object' && 'message' in res.response.data && typeof res.response.data.message === 'string' ? res.response.data.message : 'Internal Server Error - Unspecified GitHub API Error' })
+        return NextResponse.json({res: ('response' in res && res.response) || {}, statusText}, { status: res.code })
     }
 
-    return NextResponse.json(res, { status: res.status, statusText: 'response' in res && res.response && typeof res.response === 'object' && 'data' in res.response && res.response.data && typeof res.response.data === 'object' && 'message' in res.response.data && typeof res.response.data.message === 'string' ? res.response.data.message : 'Internal Server Error - Unspecified GitHub API Error' })
+    return NextResponse.json({res, statusText}, { status: res.status })
 }

--- a/src/components/join-team/joinTeamForm.tsx
+++ b/src/components/join-team/joinTeamForm.tsx
@@ -59,7 +59,13 @@ export default function JoinTeamForm(props: IProps) {
         try {
             const result = await resPromise
             setStatusCode(result.status);
-            setStatusText(result.statusText);
+            setStatusText('Loading...');
+            try {
+                await result.json().then(r => setStatusText(r.status));
+            } catch (err) {
+                if (err instanceof SyntaxError) setStatusText(result.statusText || 'Unable to understand what the SFCP web server said.');
+                else throw err;
+            }
         } catch(err) {
             console.error('Error while submitting the form:\n-----\n', err);
             setStatusText('Something went wrong. Please contact the site owner.');


### PR DESCRIPTION
Next.js strips errors/status text in production but not in the development environment). Since the form relied on status text, I've retrofitted the setup to put what was previously sent as status text into the server's response JSON instead.